### PR TITLE
dockerfile: Define the containarized env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # django-testing-tutorial
 A learnng tutorial about testing Django
+
+## Build the container environment
+
+The project environmen is defined in *dockerfile/Dockerfile*.
+
+In order to build it, use podman:
+`podman build -f dockerfile/Dockerfile -t beyond .`

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,0 +1,19 @@
+# centos:stream8
+FROM quay.io/centos/centos@sha256:82b0e76b18388f04b38267120b1178f187b5cb0b170c37bcbc6d796114b8e7be
+
+COPY requirements.txt /
+
+RUN \
+    dnf -y install \
+      python38 \
+      sqlite \
+    && \
+    dnf clean all \
+    && \
+    python3 -m pip install -r requirements.txt
+
+WORKDIR /workspace/django-testing-tutorial
+
+EXPOSE 8000/tcp
+
+CMD ["python3", "/workspace/django-testing-tutorial/manage.py", "runserver", "0.0.0.0:8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,19 @@
+# Base: centos:stream8
+
+# Django
+asgiref==3.5.0
+backports.zoneinfo==0.2.1
+Django==4.0.3
+sqlparse==0.4.2
+
+# pytest
+attrs==21.4.0
+iniconfig==1.1.1
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pyparsing==3.0.7
+pytest==7.1.0
+pytest-django==4.5.2
+tomli==2.0.1
+


### PR DESCRIPTION
Provide a containarized environment to test and run the django
project.

Containarizing the development environment allows all developers
to use the same exact components, having no dependency on the
underlay platform.

One can create an image from the Dockerfile by running:

`podman build -f dockerfile/Dockerfile -t beyond .` from the
project root.