### PR TITLE
formatter: Use black to keep consistent formating

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,6 +13,14 @@ env:
   PYTHON_VERSION: "3.8"
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+        with:
+          options: "--check --diff -S"
+          version: "22.1.0"
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,10 @@ pytest==7.1.0
 pytest-django==4.5.2
 tomli==2.0.1
 
+## black (formatter)
+black==22.1.0
+click==8.0.4
+mypy-extensions==0.4.3
+pathspec==0.9.0
+platformdirs==2.5.1
+typing-extensions==4.1.1

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
 def test_root_entrypoint(client):
     response = client.get("/")
     assert response.status_code == 200


### PR DESCRIPTION
black [1] is an opinionated python source code formatter.
It improves readability and reduces opinionated review
comments about code format, keeping also a consistent
format across the project.

This change adds `black` to the dependencies and allows
one to run it on the source code to auto-format it:
- Use `black -S ./` in your environment without a container.
- Use `podman run -ti --rm -v $(pwd):/workspace/django-testing-tutorial:Z localhost/beyond black -S ./`
  to run it with a container.

Note: The `-S` option customizes `black` to ignore the string
wrapper character (`'` or `"`). The one used by Django is not
in sync with the opinionated one `black` prefers.