### PR TITLE
member: Expose validation check for a member-role

### DIFF
--- a/member/models.py
+++ b/member/models.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from django.core.exceptions import ValidationError
 from django.db import models
 
 
@@ -45,3 +46,9 @@ class MemberRole(models.Model):
         if role is not None:
             return MemberRole.objects.filter(role=role)
         return MemberRole.objects.all()
+
+    def is_valid(self):
+        if self.member.username == self.role.name:
+            raise ValidationError(
+                f"Member username can not match role name ({self.role.name})"
+            )

--- a/member/models.py
+++ b/member/models.py
@@ -48,7 +48,10 @@ class MemberRole(models.Model):
         return MemberRole.objects.all()
 
     def is_valid(self):
-        if self.member.username == self.role.name:
+        if (
+            self.member.username in self.role.name
+            or self.role.name in self.member.username
+        ):
             raise ValidationError(
                 f"Member username can not match role name ({self.role.name})"
             )

--- a/member/tests.py
+++ b/member/tests.py
@@ -23,6 +23,8 @@
 
 import pytest
 
+from django.core.exceptions import ValidationError
+
 from . import models
 
 
@@ -137,3 +139,13 @@ class TestMemberRoleModel:
         assert [expected_filtered_member_role] == list(
             models.MemberRole.filter(member=member2filter)
         )
+
+    def test_invalid_member_role(self):
+        NAME = "foo"
+        member = models.Member(username=NAME)
+        role = models.Role(name=NAME)
+
+        member_role = models.MemberRole(member=member, role=role)
+
+        with pytest.raises(ValidationError):
+            member_role.is_valid()

--- a/member/tests.py
+++ b/member/tests.py
@@ -140,10 +140,13 @@ class TestMemberRoleModel:
             models.MemberRole.filter(member=member2filter)
         )
 
-    def test_invalid_member_role(self):
-        NAME = "foo"
-        member = models.Member(username=NAME)
-        role = models.Role(name=NAME)
+    @pytest.mark.parametrize(
+        "username, rolename",
+        [("foo", "foo"), ("foo", "fooprefix"), ("foo", "tailfoo"), ("midfoox", "foo")],
+    )
+    def test_invalid_member_role(self, username, rolename):
+        member = models.Member(username=username)
+        role = models.Role(name=rolename)
 
         member_role = models.MemberRole(member=member, role=role)
 


### PR DESCRIPTION
Add a validation check that examines the member username and role name,
making sure they are not matching.

To trigger the validation, call `is_valid` method on the `MemberRole`
object instance.
Raises a `ValidationError` excetion if names match.