### PR TITLE
member: Expose member view entrypoint

### DIFF
--- a/beyond/urls.py
+++ b/beyond/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
+    path('member/', include('member.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/member/urls.py
+++ b/member/urls.py
@@ -21,8 +21,11 @@
 # SOFTWARE.
 
 
-from django.http import HttpResponse
+from django.urls import path
+
+from . import views
 
 
-def index(request):
-    return HttpResponse("Hello, beyond member!")
+urlpatterns = [
+    path('', views.index, name='index'),
+]

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -21,6 +21,6 @@
 # SOFTWARE.
 
 
-def test_root_entrypoint(client):
-    response = client.get("/")
+def test_member_app_entrypoint(client):
+    response = client.get("/member/")
     assert response.status_code == 200


### PR DESCRIPTION
Expose the `/member/` entrypoint at the project level.

It is currently a placeholder, ready to be wired
to a view that uses the model.