### PR TITLE
member: Expose the member view that uses the model

### DIFF
--- a/member/views.py
+++ b/member/views.py
@@ -21,14 +21,13 @@
 # SOFTWARE.
 
 
-from django.http import HttpResponse
 from django.http import JsonResponse
 
 from . import models
 
 
 def index(request):
-    return HttpResponse("Hello, beyond member!")
+    return member_roles(request)
 
 
 def member_roles(request):

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -21,6 +21,10 @@
 # SOFTWARE.
 
 
+import pytest
+
+
+@pytest.mark.django_db()
 def test_member_app_entrypoint(client):
     response = client.get("/member/")
     assert response.status_code == 200


### PR DESCRIPTION
Wire the exposed view to the one that uses the model.
Accessing `/member/` reports now the list of member-roles.

~Depends on #19, #20~